### PR TITLE
fix: add navigation handlers for HomePage

### DIFF
--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,0 +1,35 @@
+function HomePage({ onNavigate }) {
+  return (
+    <div className="flex flex-col items-center justify-center space-y-4 p-6">
+      <h1 className="text-3xl font-bold">Página de inicio</h1>
+      <div className="flex flex-col space-y-2">
+        <button
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          onClick={() => onNavigate('calendar')}
+        >
+          Calendario
+        </button>
+        <button
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          onClick={() => onNavigate('packages')}
+        >
+          Paquetes
+        </button>
+        <button
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          onClick={() => onNavigate('brands')}
+        >
+          Marcas
+        </button>
+        <button
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          onClick={() => onNavigate('quiz')}
+        >
+          Quiz
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- add HomePage component with navigation buttons using `onNavigate`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b220b43bc48328ae203f10c5cc6749